### PR TITLE
[chore] 로깅 설정

### DIFF
--- a/src/main/java/com/prgrms/rg/config/WebConfig.java
+++ b/src/main/java/com/prgrms/rg/config/WebConfig.java
@@ -13,7 +13,6 @@ public class WebConfig implements WebMvcConfigurer {
 	public void addInterceptors(InterceptorRegistry registry) {
 		registry.addInterceptor(new LoggingInterceptor())
 			.order(1)
-			.addPathPatterns("/api/v1/**")
-			.excludePathPatterns("/css/**");
+			.addPathPatterns("/api/v1/**");
 	}
 }

--- a/src/main/java/com/prgrms/rg/config/WebConfig.java
+++ b/src/main/java/com/prgrms/rg/config/WebConfig.java
@@ -1,0 +1,19 @@
+package com.prgrms.rg.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import com.prgrms.rg.web.LoggingInterceptor;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+	@Override
+	public void addInterceptors(InterceptorRegistry registry) {
+		registry.addInterceptor(new LoggingInterceptor())
+			.order(1)
+			.addPathPatterns("/api/v1/**")
+			.excludePathPatterns("/css/**");
+	}
+}

--- a/src/main/java/com/prgrms/rg/web/LoggingInterceptor.java
+++ b/src/main/java/com/prgrms/rg/web/LoggingInterceptor.java
@@ -1,0 +1,23 @@
+package com.prgrms.rg.web;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class LoggingInterceptor implements HandlerInterceptor {
+
+	@Override
+	public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws
+		Exception {
+		String requestURI = request.getRequestURI();
+		String requestMethod = request.getMethod();
+
+		log.info("REQUEST [{}] [{}] [{}]", requestMethod,  requestURI, handler);
+
+		return true;
+	}
+}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -22,3 +22,6 @@ spring:
         use_sql_comments: true
 server:
   port: 80
+logging:
+  file:
+    path: ${LOG_PATH}

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <property name="LOG_PATTERN" value="%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} -- %msg%n"/>
+
+    <springProfile name="default, test">
+        <appender name="CONSOLE_LOG" class="ch.qos.logback.core.ConsoleAppender">
+            <encoder>
+                <pattern>${LOG_PATTERN}</pattern>
+            </encoder>
+        </appender>
+    </springProfile>
+
+    <springProfile name="prod">
+        <appender name="FILE_LOG" class="ch.qos.logback.core.rolling.RollingFileAppender">
+            <filter class="ch.qos.logback.classic.filter.LevelFilter">
+                <level>error</level>
+                <onMatch>DENY</onMatch>
+                <onMismatch>ACCEPT</onMismatch>
+            </filter>
+            <file>${LOG_PATH}/rg.log</file>
+            <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+                <fileNamePattern>${LOG_PATH}/%d{yyyy-MM-dd}_%i.rg.log</fileNamePattern>
+                <maxFileSize>100MB</maxFileSize>
+                <maxHistory>15</maxHistory>
+            </rollingPolicy>
+            <encoder>
+                <pattern>${LOG_PATTERN}</pattern>
+            </encoder>
+        </appender>
+    </springProfile>
+
+    <springProfile name="prod">
+        <appender name="ERROR_FILE_LOG" class="ch.qos.logback.core.rolling.RollingFileAppender">
+            <filter class="ch.qos.logback.classic.filter.LevelFilter">
+                <level>error</level>
+                <onMatch>ACCEPT</onMatch>
+                <onMismatch>DENY</onMismatch>
+            </filter>
+            <file>${LOG_PATH}/error.log</file>
+            <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
+                <fileNamePattern>${LOG_PATH}/error_%i.log.gz</fileNamePattern>
+                <minIndex>1</minIndex>
+                <maxIndex>3</maxIndex>
+            </rollingPolicy>
+
+            <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
+                <maxFileSize>50MB</maxFileSize>
+            </triggeringPolicy>
+
+            <param name="MaxBackupIndex" value="2"/>
+            <encoder>
+                <pattern>${LOG_PATTERN}</pattern>
+            </encoder>
+        </appender>
+    </springProfile>
+
+    <springProfile name="default, test">
+        <root level="info">
+            <appender-ref ref="CONSOLE_LOG"/>
+        </root>
+    </springProfile>
+
+    <springProfile name="prod">
+        <root level="info">
+            <appender-ref ref="FILE_LOG"/>
+            <appender-ref ref="ERROR_FILE_LOG"/>
+        </root>
+    </springProfile>
+
+</configuration>


### PR DESCRIPTION
- 인터셉터를 통한 request 로깅


- profile에 따른 로깅 설정
- 로깅 레벨에 따른 로깅 설정(prod profile)


1. 인터셉터의 작동이 헨들러를 감싸는 위치에서 동작하므로, web 패키지에 loggingInterceptor 클래스를 위치하게 했습니다. 더 괜찮은 위치 있다면 말해주세요!

++ appender 부분에 springprofile 태그를 적용하지 않으면 프로파일에 따른 로깅 방식이 제대로 적용되지 않아서 추가했습니다