### PR TITLE
[feat] 배포 서버 오류 메시지 전송

### DIFF
--- a/.github/workflows/CICD-main.yml
+++ b/.github/workflows/CICD-main.yml
@@ -65,6 +65,8 @@ jobs:
           context: .
           build-args: |
             PINPOINT_HOST=${{ secrets.PINPOINT_HOST }}
+            SLACK_CHANNEL_NAME=${{ secrets.SLACK_CHANNEL_NAME }}
+            SLACK_AUTH_TOKEN=${{ secrets.SLACK_AUTH_TOKEN }}
 
       - name: Install SSH Key
         uses: shimataro/ssh-key-action@v2

--- a/dockerfile
+++ b/dockerfile
@@ -1,12 +1,17 @@
 FROM openjdk:11
 
+# PINPOINT_HOST 는 외부 시스템에서 가져옵니다. (build-time arg)
+ARG PINPOINT_HOST
+ARG SLACK_CHANNEL_NAME
+ARG SLACK_AUTH_TOKEN
+
 # CI가 성공해서 build된 jar가 이미 존재합니다.
 ENV JAR_PATH=build/libs
 ENV JAR_NAME=*SNAPSHOT.jar
 ENV PINPOINT_DIR=/app/pinpoint-agent-2.4.0
 ENV LOG_PATH=./log
-# PINPOINT_HOST 는 외부 시스템에서 가져옵니다. (build-time arg)
-ARG PINPOINT_HOST
+ENV SLACK_CHANNEL_NAME=$SLACK_CHANNEL_NAME
+ENV SLACK_AUTH_TOKEN=$SLACK_AUTH_TOKEN
 
 # naver pinpoint 설치 및 환경 설정
 RUN mkdir /app

--- a/src/main/java/com/prgrms/rg/RgApplication.java
+++ b/src/main/java/com/prgrms/rg/RgApplication.java
@@ -6,7 +6,7 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-import com.prgrms.rg.infrastructure.cloud.message.CriticalMessageSender;
+import com.prgrms.rg.infrastructure.cloud.CriticalMessageSender;
 
 @EnableJpaAuditing
 @SpringBootApplication

--- a/src/main/java/com/prgrms/rg/RgApplication.java
+++ b/src/main/java/com/prgrms/rg/RgApplication.java
@@ -1,16 +1,33 @@
 package com.prgrms.rg;
 
+import java.io.IOException;
+
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+import com.prgrms.rg.infrastructure.cloud.message.CriticalMessageSender;
+
 @EnableJpaAuditing
 @SpringBootApplication
 public class RgApplication {
-	public static void main(String[] args) {
+	public static void main(String[] args) throws IOException {
 		// 애플리케이션을 ec2에서만 사용할 것이 아니므로, spring cloud aws에서 ec2메타데이터를 받아오는 것이 불필요함
 		System.setProperty("com.amazonaws.sdk.disableEc2Metadata", "true");
-		SpringApplication.run(RgApplication.class, args);
+
+		/*
+		 * 초기 profile entry point를 확인합니다. (prod 아니면 default)
+		 */
+		var initialProfile = System.getProperty("spring.profiles.active");
+		try {
+			SpringApplication.run(RgApplication.class, args);
+		} catch (Exception exception) {
+			// 초기 profile이 prod를 포함할 경우에만 특정 모듈에 메시지를 보냅니다.
+			if (initialProfile != null && initialProfile.matches("prod")) {
+				new CriticalMessageSender().send(exception);
+			}
+			throw exception;
+		}
 
 	}
 }

--- a/src/main/java/com/prgrms/rg/RgApplication.java
+++ b/src/main/java/com/prgrms/rg/RgApplication.java
@@ -1,7 +1,5 @@
 package com.prgrms.rg;
 
-import java.io.IOException;
-
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
@@ -11,7 +9,7 @@ import com.prgrms.rg.infrastructure.cloud.CriticalMessageSender;
 @EnableJpaAuditing
 @SpringBootApplication
 public class RgApplication {
-	public static void main(String[] args) throws IOException {
+	public static void main(String[] args) throws Exception {
 		// 애플리케이션을 ec2에서만 사용할 것이 아니므로, spring cloud aws에서 ec2메타데이터를 받아오는 것이 불필요함
 		System.setProperty("com.amazonaws.sdk.disableEc2Metadata", "true");
 
@@ -24,7 +22,7 @@ public class RgApplication {
 		} catch (Exception exception) {
 			// 초기 profile이 prod를 포함할 경우에만 특정 모듈에 메시지를 보냅니다.
 			if (initialProfile != null && initialProfile.matches("prod")) {
-				new CriticalMessageSender().send(exception);
+				CriticalMessageSender.send(exception);
 			}
 			throw exception;
 		}

--- a/src/main/java/com/prgrms/rg/infrastructure/cloud/CriticalMessageSender.java
+++ b/src/main/java/com/prgrms/rg/infrastructure/cloud/CriticalMessageSender.java
@@ -11,48 +11,49 @@ import java.util.Map;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import lombok.experimental.UtilityClass;
+
 /**
  * 스프링에서 처리하지 못한 예외 메시지를 자바 애플리케이션 종료 직전에 외부 시스템에 전송합니다.
  * TODO : 추상화
  */
+@UtilityClass
 public class CriticalMessageSender {
 
 	private static final String SLACK_CHANNEL_ID = System.getenv("SLACK_CHANNEL_NAME");
 	private static final String SLACK_AUTH_TOKEN = System.getenv("SLACK_AUTH_TOKEN");
 
-	public void send(Exception exception) throws JsonProcessingException {
+	public static void send(Exception exception) throws Exception {
 		String body = createMessageBodyFrom(exception);
 		sendHttpRequest(body);
 	}
 
-	private void sendHttpRequest(String body) {
-		try {
-			URL url = new URL("https://slack.com/api/chat.postMessage");
-			HttpURLConnection conn = (HttpURLConnection)url.openConnection();
-			// request 헤더, 토큰 설정
-			conn.setDoOutput(true);
-			conn.setRequestMethod("POST");
-			conn.setRequestProperty("Content-Type", "application/json");
-			conn.setRequestProperty("Accept-Charset", "UTF-8");
-			conn.setConnectTimeout(5000); // 커넥션 생성 대기 시간(해당 시간 안에 커넥션 생성 안되면 SocketTimeoutException
-			conn.setReadTimeout(5000);
-			conn.setRequestProperty("Authorization", "Bearer " + SLACK_AUTH_TOKEN);
+	private static void sendHttpRequest(String body) throws Exception {
 
-			// Json을 Http 요청 body에 담는다.
-			OutputStream os = conn.getOutputStream();
-			os.write(body.getBytes(StandardCharsets.UTF_8));
-			os.flush();
+		URL url = new URL("https://slack.com/api/chat.postMessage");
+		HttpURLConnection conn = (HttpURLConnection)url.openConnection();
+		// request 헤더, 토큰 설정
+		conn.setDoOutput(true);
+		conn.setRequestMethod("POST");
+		conn.setRequestProperty("Content-Type", "application/json");
+		conn.setRequestProperty("Accept-Charset", "UTF-8");
+		conn.setConnectTimeout(5000); // 커넥션 생성 대기 시간(해당 시간 안에 커넥션 생성 안되면 SocketTimeoutException
+		conn.setReadTimeout(5000);
+		conn.setRequestProperty("Authorization", "Bearer " + SLACK_AUTH_TOKEN);
 
-			// Http 요청을 보내고 응답을 inputStream에 받아 온다.
-			conn.getInputStream();
+		// Json을 Http 요청 body에 담는다.
+		OutputStream os = conn.getOutputStream();
+		os.write(body.getBytes(StandardCharsets.UTF_8));
+		os.flush();
 
-			conn.disconnect();
-		} catch (Exception e) {
-			e.printStackTrace();
-		}
+		// Http 요청을 보내고 응답을 inputStream에 받아 온다.
+		// 이 메서드를 사용하지 않으면 http 요청을 보내지 않기 때문에, 무조건 사용
+		conn.getInputStream();
+
+		conn.disconnect();
 	}
 
-	private String createMessageBodyFrom(Exception exception) throws JsonProcessingException {
+	private static String createMessageBodyFrom(Exception exception) throws JsonProcessingException {
 		ObjectMapper json = new ObjectMapper();
 		var stackStream = new ByteArrayOutputStream();
 		exception.printStackTrace(new PrintStream(stackStream));

--- a/src/main/java/com/prgrms/rg/infrastructure/cloud/CriticalMessageSender.java
+++ b/src/main/java/com/prgrms/rg/infrastructure/cloud/CriticalMessageSender.java
@@ -1,8 +1,6 @@
-package com.prgrms.rg.infrastructure.cloud.message;
+package com.prgrms.rg.infrastructure.cloud;
 
-import java.io.BufferedReader;
 import java.io.ByteArrayOutputStream;
-import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.PrintStream;
 import java.net.HttpURLConnection;
@@ -14,7 +12,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
- * 스프링에서 처리하지 못한 예외 메시지를 자바 애플리케이션 종료 직전에 특정 컴포넌트에 전송시킵니다.
+ * 스프링에서 처리하지 못한 예외 메시지를 자바 애플리케이션 종료 직전에 외부 시스템에 전송합니다.
  * TODO : 추상화
  */
 public class CriticalMessageSender {
@@ -23,41 +21,48 @@ public class CriticalMessageSender {
 	private static final String SLACK_AUTH_TOKEN = System.getenv("SLACK_AUTH_TOKEN");
 
 	public void send(Exception exception) throws JsonProcessingException {
-		ObjectMapper json = new ObjectMapper();
-		var exceptionStream = new ByteArrayOutputStream();
-		exception.printStackTrace(new PrintStream(exceptionStream));
-		String emoji = ":meow_sad:\t";
-		StringBuilder emojiBuffer = new StringBuilder();
-		emojiBuffer.append(emoji.repeat(20));
-		emojiBuffer.append("\n").append(exceptionStream.toString(StandardCharsets.UTF_8)).append("\n");
-		emojiBuffer.append(emoji.repeat(20));
+		String body = createMessageBodyFrom(exception);
+		sendHttpRequest(body);
+	}
 
-		String body = json.writeValueAsString(
-			Map.of("channel", SLACK_CHANNEL_ID, "text", emojiBuffer));
+	private void sendHttpRequest(String body) {
 		try {
 			URL url = new URL("https://slack.com/api/chat.postMessage");
 			HttpURLConnection conn = (HttpURLConnection)url.openConnection();
+			// request 헤더, 토큰 설정
 			conn.setDoOutput(true);
 			conn.setRequestMethod("POST");
 			conn.setRequestProperty("Content-Type", "application/json");
 			conn.setRequestProperty("Accept-Charset", "UTF-8");
 			conn.setConnectTimeout(5000); // 커넥션 생성 대기 시간(해당 시간 안에 커넥션 생성 안되면 SocketTimeoutException
 			conn.setReadTimeout(5000);
-			conn.setRequestProperty("Authorization",
-				"Bearer " + SLACK_AUTH_TOKEN);
+			conn.setRequestProperty("Authorization", "Bearer " + SLACK_AUTH_TOKEN);
 
+			// Json을 Http 요청 body에 담는다.
 			OutputStream os = conn.getOutputStream();
 			os.write(body.getBytes(StandardCharsets.UTF_8));
 			os.flush();
 
-			// 리턴된 결과 읽기
-			BufferedReader in = new BufferedReader(new InputStreamReader(conn.getInputStream(), "UTF-8"));
-			in.lines().forEach((str) -> {
-			});
+			// Http 요청을 보내고 응답을 inputStream에 받아 온다.
+			conn.getInputStream();
+
 			conn.disconnect();
 		} catch (Exception e) {
 			e.printStackTrace();
 		}
+	}
+
+	private String createMessageBodyFrom(Exception exception) throws JsonProcessingException {
+		ObjectMapper json = new ObjectMapper();
+		var stackStream = new ByteArrayOutputStream();
+		exception.printStackTrace(new PrintStream(stackStream));
+		String emoji = ":meow_sad:\t";
+		StringBuilder emojiBuffer = new StringBuilder();
+		emojiBuffer.append(emoji.repeat(20));
+		emojiBuffer.append("\n").append(stackStream.toString(StandardCharsets.UTF_8)).append("\n");
+		emojiBuffer.append(emoji.repeat(20));
+
+		return json.writeValueAsString(Map.of("channel", SLACK_CHANNEL_ID, "text", emojiBuffer));
 	}
 
 }

--- a/src/main/java/com/prgrms/rg/infrastructure/cloud/message/CriticalMessageSender.java
+++ b/src/main/java/com/prgrms/rg/infrastructure/cloud/message/CriticalMessageSender.java
@@ -1,8 +1,10 @@
 package com.prgrms.rg.infrastructure.cloud.message;
 
 import java.io.BufferedReader;
+import java.io.ByteArrayOutputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
+import java.io.PrintStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
@@ -22,8 +24,16 @@ public class CriticalMessageSender {
 
 	public void send(Exception exception) throws JsonProcessingException {
 		ObjectMapper json = new ObjectMapper();
-		String body = json.writeValueAsString(Map.of("channel", SLACK_CHANNEL_ID, "text", exception.fillInStackTrace()
-			.getMessage()));
+		var exceptionStream = new ByteArrayOutputStream();
+		exception.printStackTrace(new PrintStream(exceptionStream));
+		String emoji = ":meow_sad:\t";
+		StringBuilder emojiBuffer = new StringBuilder();
+		emojiBuffer.append(emoji.repeat(20));
+		emojiBuffer.append("\n").append(exceptionStream.toString(StandardCharsets.UTF_8)).append("\n");
+		emojiBuffer.append(emoji.repeat(20));
+
+		String body = json.writeValueAsString(
+			Map.of("channel", SLACK_CHANNEL_ID, "text", emojiBuffer));
 		try {
 			URL url = new URL("https://slack.com/api/chat.postMessage");
 			HttpURLConnection conn = (HttpURLConnection)url.openConnection();
@@ -31,7 +41,7 @@ public class CriticalMessageSender {
 			conn.setRequestMethod("POST");
 			conn.setRequestProperty("Content-Type", "application/json");
 			conn.setRequestProperty("Accept-Charset", "UTF-8");
-			conn.setConnectTimeout(5000); // 커넥션 생성 대기 시간(해당 시간 안에 커넥션 생성 안되면 SocketTimeoutException)
+			conn.setConnectTimeout(5000); // 커넥션 생성 대기 시간(해당 시간 안에 커넥션 생성 안되면 SocketTimeoutException
 			conn.setReadTimeout(5000);
 			conn.setRequestProperty("Authorization",
 				"Bearer " + SLACK_AUTH_TOKEN);

--- a/src/main/java/com/prgrms/rg/infrastructure/cloud/message/CriticalMessageSender.java
+++ b/src/main/java/com/prgrms/rg/infrastructure/cloud/message/CriticalMessageSender.java
@@ -1,0 +1,53 @@
+package com.prgrms.rg.infrastructure.cloud.message;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * 스프링에서 처리하지 못한 예외 메시지를 자바 애플리케이션 종료 직전에 특정 컴포넌트에 전송시킵니다.
+ * TODO : 추상화
+ */
+public class CriticalMessageSender {
+
+	private static final String SLACK_CHANNEL_ID = System.getenv("SLACK_CHANNEL_NAME");
+	private static final String SLACK_AUTH_TOKEN = System.getenv("SLACK_AUTH_TOKEN");
+
+	public void send(Exception exception) throws JsonProcessingException {
+		ObjectMapper json = new ObjectMapper();
+		String body = json.writeValueAsString(Map.of("channel", SLACK_CHANNEL_ID, "text", exception.fillInStackTrace()
+			.getMessage()));
+		try {
+			URL url = new URL("https://slack.com/api/chat.postMessage");
+			HttpURLConnection conn = (HttpURLConnection)url.openConnection();
+			conn.setDoOutput(true);
+			conn.setRequestMethod("POST");
+			conn.setRequestProperty("Content-Type", "application/json");
+			conn.setRequestProperty("Accept-Charset", "UTF-8");
+			conn.setConnectTimeout(5000); // 커넥션 생성 대기 시간(해당 시간 안에 커넥션 생성 안되면 SocketTimeoutException)
+			conn.setReadTimeout(5000);
+			conn.setRequestProperty("Authorization",
+				"Bearer " + SLACK_AUTH_TOKEN);
+
+			OutputStream os = conn.getOutputStream();
+			os.write(body.getBytes(StandardCharsets.UTF_8));
+			os.flush();
+
+			// 리턴된 결과 읽기
+			BufferedReader in = new BufferedReader(new InputStreamReader(conn.getInputStream(), "UTF-8"));
+			in.lines().forEach((str) -> {
+			});
+			conn.disconnect();
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+	}
+
+}


### PR DESCRIPTION
Closes #29 

## 설명

초기 실행 profile이 prod일 때만 작동하는 메시지 전송 컴포넌트입니다.

현재 [클라우드 에러 전송 슬랙 채널](https://greppkdt-webdev.slack.com/archives/C03RPDSEW5B) 에서 메시지를 수신하고 있습니다.

리팩터링은 우선순위에서 떨어지는 것 같아서 일단 미뤘습니다.

**도메인과 직접적으로 관련된 사항은 아니니 가볍게 보고 넘어가시면 될 것 같습니다.**

## 상황 

로컬에서는 메시지가 성공적으로 슬랙에 전송되는 것이 확인됐으나, 실제 클라우드에서는 어떻게 작동하는지 확인해봐야 합니다. 

아마 OAuth 까지 develop에 merge된 다음에 release 브랜치에서 main으로 merge할 때 같이 살펴볼 것 같습니다.