### PR TITLE
[refactor] oauth 관련 테이블 관리 주체 변경

### DIFF
--- a/src/main/java/com/prgrms/rg/config/WebSecurityConfigure.java
+++ b/src/main/java/com/prgrms/rg/config/WebSecurityConfigure.java
@@ -1,13 +1,9 @@
 package com.prgrms.rg.config;
 
-import javax.annotation.PostConstruct;
-import javax.annotation.PreDestroy;
 import javax.servlet.http.HttpServletResponse;
-import javax.sql.DataSource;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.jdbc.core.JdbcOperations;
-import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.builders.WebSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -146,32 +142,6 @@ public class WebSecurityConfigure extends WebSecurityConfigurerAdapter {
 			 */
 			.addFilterAfter(jwtAuthenticationFilter(), SecurityContextPersistenceFilter.class)
 		;
-	}
-
-	@PostConstruct
-	public void setSchema() {
-		var datasource = getApplicationContext().getBean(DataSource.class);
-		new JdbcTemplate(datasource).update("CREATE TABLE oauth2_authorized_client\n"
-			+ "(\n"
-			+ "    client_registration_id  varchar(100)                            NOT NULL,\n"
-			+ "    principal_name          varchar(200)                            NOT NULL,\n"
-			+ "    access_token_type       varchar(100)                            NOT NULL,\n"
-			+ "    access_token_value      blob                                    NOT NULL,\n"
-			+ "    access_token_issued_at  timestamp                               NOT NULL,\n"
-			+ "    access_token_expires_at timestamp                               NOT NULL,\n"
-			+ "    access_token_scopes     varchar(1000) DEFAULT NULL,\n"
-			+ "    refresh_token_value     blob          DEFAULT NULL,\n"
-			+ "    refresh_token_issued_at timestamp     DEFAULT NULL,\n"
-			+ "    created_at              timestamp     DEFAULT CURRENT_TIMESTAMP NOT NULL,\n"
-			+ "    PRIMARY KEY (client_registration_id, principal_name)\n"
-			+ ");");
-	}
-
-	@PreDestroy
-	public void preDestroy() {
-		var datasource = getApplicationContext().getBean(DataSource.class);
-		new JdbcTemplate(datasource).update("DROP TABLE oauth2_authorized_client");
-
 	}
 
 }

--- a/src/main/java/com/prgrms/rg/domain/auth/model/OAuth2AuthorizedClient.java
+++ b/src/main/java/com/prgrms/rg/domain/auth/model/OAuth2AuthorizedClient.java
@@ -1,0 +1,69 @@
+package com.prgrms.rg.domain.auth.model;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Lob;
+import javax.persistence.Table;
+
+@Entity
+@Table(name = "oauth2_authorized_client")
+public class OAuth2AuthorizedClient {
+
+	@Id
+	private Key primaryKey;
+
+	@Column(length = 100, nullable = false, name = "access_token_type")
+	private String accessTokenType;
+
+	@Lob
+	@Column(name = "access_token_value", columnDefinition = "blob", nullable = false)
+	private byte[] accessTokenValue;
+
+	@Column(name = "access_token_issued_at", columnDefinition = "timestamp", nullable = false)
+	private LocalDateTime accessTokenIssuedAt;
+
+	@Column(name = "access_token_expires_at", columnDefinition = "timestamp", nullable = false)
+	private LocalDateTime accessTokenExpiresAt;
+
+	@Column(name = "access_token_scopes", length = 1000, nullable = false)
+	private String accessTokenScopes;
+
+	@Lob
+	@Column(name = "refresh_token_value", columnDefinition = "blob")
+	private byte[] refreshTokenValue;
+
+	@Column(name = "refresh_token_issued_at", columnDefinition = "timestamp")
+	private LocalDateTime refreshTokenIssuedAt;
+
+	@Column(name = "created_at", columnDefinition = "timestamp default CURRENT_TIMESTAMP not null")
+	private LocalDateTime createdAt;
+
+	@Embeddable
+	static class Key implements Serializable {
+		@Column(name = "client_registration_id", length = 100, nullable = false)
+		private String clientRegistrationId;
+		@Column(name = "principal_name", length = 200, nullable = false)
+		private String principalName;
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o)
+				return true;
+			if (!(o instanceof Key))
+				return false;
+			Key key = (Key)o;
+			return clientRegistrationId.equals(key.clientRegistrationId) && principalName.equals(key.principalName);
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(clientRegistrationId, principalName);
+		}
+	}
+}


### PR DESCRIPTION
## 내용

Oauth 관련 테이블의 관리 방식을 sql이 아닌 JPA에서 관리하도록 변경했습니다. 
JPA 관련 DDL(create-drop)이 성공적으로 수행된 뒤에 시큐리티 설정 코드가 실행된다는 점을 이용했습니다.


정상적으로 토큰도 불러옵니다.

![image](https://user-images.githubusercontent.com/19306609/182312572-71ae777b-a401-48df-b8ee-efe2f672c9e1.png)


`@HunkiKim 님이 나중에 확인하시고 이상 없으면 merge 하시면 될 것 같습니다`
## 궁금한 사항

합성 키나 timestamp 관련 Entity 코드를 일단 테이블 DDL에 끼워맞춰 작성하기는 했는데, 잠재적인 문제점이 있으면 지적해주세요! JPA는 볼 때마다 어색하네요