### PR TITLE
[feat] 라이딩 댓글 작성 및 조회

### DIFF
--- a/src/main/java/com/prgrms/rg/domain/ridingpost/application/RidingPostCommentService.java
+++ b/src/main/java/com/prgrms/rg/domain/ridingpost/application/RidingPostCommentService.java
@@ -1,7 +1,12 @@
 package com.prgrms.rg.domain.ridingpost.application;
 
+import java.util.List;
+
 import com.prgrms.rg.domain.ridingpost.application.command.RidingPostCommentCreateCommand;
+import com.prgrms.rg.domain.ridingpost.application.information.RidingPostCommentInfo;
 
 public interface RidingPostCommentService {
 	long createComment(RidingPostCommentCreateCommand command);
+
+	List<RidingPostCommentInfo> getCommentsByPostId(long ridingPostId);
 }

--- a/src/main/java/com/prgrms/rg/domain/ridingpost/application/command/RidingPostCommentCreateCommand.java
+++ b/src/main/java/com/prgrms/rg/domain/ridingpost/application/command/RidingPostCommentCreateCommand.java
@@ -9,9 +9,10 @@ import lombok.RequiredArgsConstructor;
 public class RidingPostCommentCreateCommand {
 	private final long authorId;
 	private final long postId;
+	private final Long parentCommentId;
 	private final String content;
 
-	public static RidingPostCommentCreateCommand of(long authorId, long postId, String content) {
-		return new RidingPostCommentCreateCommand(authorId, postId, content);
+	public static RidingPostCommentCreateCommand of(long authorId, long postId, Long parentCommentId, String content) {
+		return new RidingPostCommentCreateCommand(authorId, postId, parentCommentId, content);
 	}
 }

--- a/src/main/java/com/prgrms/rg/domain/ridingpost/application/impl/RidingPostCommentServiceImpl.java
+++ b/src/main/java/com/prgrms/rg/domain/ridingpost/application/impl/RidingPostCommentServiceImpl.java
@@ -1,6 +1,10 @@
 package com.prgrms.rg.domain.ridingpost.application.impl;
 
+import java.util.NoSuchElementException;
+import java.util.Objects;
+
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.prgrms.rg.domain.common.RelatedEntityNotFoundException;
 import com.prgrms.rg.domain.ridingpost.application.RidingPostCommentService;
@@ -13,6 +17,7 @@ import com.prgrms.rg.domain.user.application.UserReadService;
 import com.prgrms.rg.domain.user.model.User;
 
 @Service
+@Transactional(readOnly = true)
 public class RidingPostCommentServiceImpl implements RidingPostCommentService {
 
 	private final UserReadService userReadService;
@@ -21,24 +26,42 @@ public class RidingPostCommentServiceImpl implements RidingPostCommentService {
 
 	private final RidingPostCommentRepository ridingPostCommentRepository;
 
-	public RidingPostCommentServiceImpl(UserReadService userReadService, RidingPostReadService ridingPostReadService,
+	public RidingPostCommentServiceImpl(
+		UserReadService userReadService,
+		RidingPostReadService ridingPostReadService,
 		RidingPostCommentRepository ridingPostCommentRepository) {
 		this.userReadService = userReadService;
 		this.ridingPostReadService = ridingPostReadService;
 		this.ridingPostCommentRepository = ridingPostCommentRepository;
 	}
 
+	/*
+	parentId가 있으면 대댓글
+	parentId가 없으면 댓글
+	 */
 	@Override
+	@Transactional
 	public long createComment(RidingPostCommentCreateCommand command) {
 		User author;
 		RidingPost post;
+		Long parentId = command.getParentCommentId();
+
 		try {
 			author = userReadService.getUserEntityById(command.getAuthorId());
 			post = ridingPostReadService.getRidingPostById(command.getPostId());
-		} catch (RuntimeException exception) {
+		} catch (NoSuchElementException exception) {
 			throw new RelatedEntityNotFoundException(exception);
 		}
 
+		// 부모 comment가 있을 경우 자식 comment는 post와 연관 관계를 갖지 않는다.
+		// 추후 postid 기반으로 탐색할 때 nested된 comment들을 탐색하는 것을 막기 위함
+		if (Objects.nonNull(parentId) && parentId > 0) {
+			var parentComment = ridingPostCommentRepository.findById(parentId);
+			var comment = RidingPostComment.createChildPost(author, parentComment, command.getContent());
+			comment = ridingPostCommentRepository.save(comment);
+			ridingPostCommentRepository.save(parentComment);
+			return comment.getId();
+		}
 		var comment = RidingPostComment.of(author, post, command.getContent());
 		return ridingPostCommentRepository.save(comment).getId();
 	}

--- a/src/main/java/com/prgrms/rg/domain/ridingpost/application/impl/RidingPostCommentServiceImpl.java
+++ b/src/main/java/com/prgrms/rg/domain/ridingpost/application/impl/RidingPostCommentServiceImpl.java
@@ -71,7 +71,6 @@ public class RidingPostCommentServiceImpl implements RidingPostCommentService {
 	}
 
 	@Override
-	@Transactional
 	public List<RidingPostCommentInfo> getCommentsByPostId(long ridingPostId) {
 		RidingPost post;
 		try {

--- a/src/main/java/com/prgrms/rg/domain/ridingpost/application/information/RidingPostCommentInfo.java
+++ b/src/main/java/com/prgrms/rg/domain/ridingpost/application/information/RidingPostCommentInfo.java
@@ -1,0 +1,40 @@
+package com.prgrms.rg.domain.ridingpost.application.information;
+
+import java.time.LocalDateTime;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.prgrms.rg.domain.ridingpost.model.RidingPostComment;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder(access = AccessLevel.PRIVATE)
+public class RidingPostCommentInfo {
+	private final long commentId;
+	private final long parentCommentId;
+	private final long authorId;
+	private final String authorName;
+	private final String contents;
+	private final LocalDateTime createdAt;
+	private final List<RidingPostCommentInfo> childComments;
+
+	public static RidingPostCommentInfo from(RidingPostComment comment) {
+		return builder()
+			.authorId(comment.getAuthor().getId())
+			.parentCommentId(comment.getParentComment() == null ? 0L : comment.getParentComment().getId())
+			.childComments(comment.getChildComments()
+				.stream()
+				.map(RidingPostCommentInfo::from)
+				.sorted(Comparator.comparing(RidingPostCommentInfo::getCreatedAt))
+				.collect(Collectors.toUnmodifiableList()))
+			.commentId(comment.getId())
+			.authorName(comment.getAuthor().getNickname())
+			.contents(comment.getContent())
+			.createdAt(comment.getCreatedAt())
+			.build();
+	}
+}

--- a/src/main/java/com/prgrms/rg/domain/ridingpost/model/RidingPostComment.java
+++ b/src/main/java/com/prgrms/rg/domain/ridingpost/model/RidingPostComment.java
@@ -56,11 +56,11 @@ public class RidingPostComment extends BaseTimeEntity {
 		this.childComments = new ArrayList<>();
 	}
 
-	public static RidingPostComment of(User author, RidingPost post, String content) {
+	public static RidingPostComment createRootComment(User author, RidingPost post, String content) {
 		return new RidingPostComment(author, post, content);
 	}
 
-	public static RidingPostComment createChildPost(User author, RidingPostComment parentComment, String content) {
+	public static RidingPostComment createChildComment(User author, RidingPostComment parentComment, String content) {
 		var newPost = new RidingPostComment(author, null, content);
 		newPost.assignToParent(parentComment);
 		return newPost;

--- a/src/main/java/com/prgrms/rg/domain/ridingpost/model/RidingPostComment.java
+++ b/src/main/java/com/prgrms/rg/domain/ridingpost/model/RidingPostComment.java
@@ -3,12 +3,17 @@ package com.prgrms.rg.domain.ridingpost.model;
 import static com.google.common.base.Preconditions.*;
 import static javax.persistence.FetchType.*;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
 
 import org.apache.logging.log4j.util.Strings;
 
@@ -30,22 +35,61 @@ public class RidingPostComment extends BaseTimeEntity {
 	@ManyToOne(optional = false, fetch = LAZY)
 	private User author;
 
-	@ManyToOne(optional = false, fetch = LAZY)
+	@ManyToOne(fetch = LAZY)
 	private RidingPost ridingPost;
+
+	@ManyToOne(fetch = LAZY)
+	private RidingPostComment parentComment;
+
+	@OneToMany(mappedBy = "parentComment")
+	private List<RidingPostComment> childComments;
 
 	@Column(length = 500, nullable = false)
 	private String content;
 
 	private RidingPostComment(User author, RidingPost ridingPost, String content) {
 		checkNotNull(author);
-		checkNotNull(ridingPost);
 		checkArgument(Strings.isNotBlank(content));
 		this.author = author;
 		this.ridingPost = ridingPost;
 		this.content = content;
+		this.childComments = new ArrayList<>();
 	}
 
 	public static RidingPostComment of(User author, RidingPost post, String content) {
 		return new RidingPostComment(author, post, content);
+	}
+
+	public static RidingPostComment createChildPost(User author, RidingPostComment parentComment, String content) {
+		var newPost = new RidingPostComment(author, null, content);
+		newPost.assignToParent(parentComment);
+		return newPost;
+	}
+
+	// TODO : 엔티티 분리
+	public boolean isRootComment() {
+		return Objects.nonNull(ridingPost);
+	}
+
+	private void assignToParent(RidingPostComment parentComment) {
+		checkArgument(!isRootComment(), "RidingPost가 존재할 경우 부모 댓글에 할당할 수 없습니다.");
+		checkNotNull(parentComment);
+		parentComment.getChildComments().add(this);
+		this.parentComment = parentComment;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o)
+			return true;
+		if (!(o instanceof RidingPostComment))
+			return false;
+		RidingPostComment comment = (RidingPostComment)o;
+		return getId().equals(comment.getId());
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(getId());
 	}
 }

--- a/src/main/java/com/prgrms/rg/domain/ridingpost/model/RidingPostCommentRepository.java
+++ b/src/main/java/com/prgrms/rg/domain/ridingpost/model/RidingPostCommentRepository.java
@@ -1,7 +1,11 @@
 package com.prgrms.rg.domain.ridingpost.model;
 
+import java.util.List;
+
 public interface RidingPostCommentRepository {
 	RidingPostComment findById(long commentId);
 
 	RidingPostComment save(RidingPostComment ridingPostComment);
+
+	List<RidingPostComment> findAllByRidingPost(RidingPost ridingPost);
 }

--- a/src/main/java/com/prgrms/rg/domain/ridingpost/model/exception/RidingPostNotFoundException.java
+++ b/src/main/java/com/prgrms/rg/domain/ridingpost/model/exception/RidingPostNotFoundException.java
@@ -1,6 +1,8 @@
 package com.prgrms.rg.domain.ridingpost.model.exception;
 
-public class RidingPostNotFoundException extends RuntimeException {
+import java.util.NoSuchElementException;
+
+public class RidingPostNotFoundException extends NoSuchElementException {
 	public RidingPostNotFoundException(Long id) {
 		super("유효하지 않은 게시글 id : '" + id + "'");
 	}

--- a/src/main/java/com/prgrms/rg/infrastructure/repository/JpaRidingPostCommentRepository.java
+++ b/src/main/java/com/prgrms/rg/infrastructure/repository/JpaRidingPostCommentRepository.java
@@ -1,9 +1,13 @@
 package com.prgrms.rg.infrastructure.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import com.prgrms.rg.domain.ridingpost.model.RidingPost;
 import com.prgrms.rg.domain.ridingpost.model.RidingPostComment;
 import com.prgrms.rg.domain.ridingpost.model.RidingPostCommentRepository;
 
 public interface JpaRidingPostCommentRepository extends JpaRepository<RidingPostComment, Long>, RidingPostCommentRepository {
+	List<RidingPostComment> findAllByRidingPost(RidingPost ridingPost);
 }

--- a/src/main/java/com/prgrms/rg/infrastructure/repository/JpaRidingPostRepository.java
+++ b/src/main/java/com/prgrms/rg/infrastructure/repository/JpaRidingPostRepository.java
@@ -1,10 +1,13 @@
 package com.prgrms.rg.infrastructure.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.prgrms.rg.domain.ridingpost.model.RidingPost;
 import com.prgrms.rg.domain.ridingpost.model.RidingPostRepository;
 
 public interface JpaRidingPostRepository extends JpaRepository<RidingPost, Long>, RidingPostRepository {
-
+	@Override
+	Optional<RidingPost> findById(Long aLong);
 }

--- a/src/main/java/com/prgrms/rg/web/ridingpost/api/RidingPostCommentController.java
+++ b/src/main/java/com/prgrms/rg/web/ridingpost/api/RidingPostCommentController.java
@@ -31,7 +31,7 @@ public class RidingPostCommentController {
 		@PathVariable("postid") long postId,
 		@AuthenticationPrincipal JwtAuthentication auth) {
 		var userId = auth.userId;
-		var command = RidingPostCommentCreateCommand.of(userId, postId, request.getContent());
+		var command = RidingPostCommentCreateCommand.of(userId, postId, request.getParentCommentId(), request.getContent());
 
 		var commentId = commentService.createComment(command);
 

--- a/src/main/java/com/prgrms/rg/web/ridingpost/api/RidingPostCommentController.java
+++ b/src/main/java/com/prgrms/rg/web/ridingpost/api/RidingPostCommentController.java
@@ -4,6 +4,7 @@ import javax.validation.Valid;
 
 import org.springframework.security.access.annotation.Secured;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -14,6 +15,7 @@ import com.prgrms.rg.domain.ridingpost.application.RidingPostCommentService;
 import com.prgrms.rg.domain.ridingpost.application.command.RidingPostCommentCreateCommand;
 import com.prgrms.rg.web.common.results.CommandSuccessResult;
 import com.prgrms.rg.web.ridingpost.requests.RidingPostCommentCreateRequest;
+import com.prgrms.rg.web.ridingpost.results.RidingPostCommentListResult;
 
 @RestController
 public class RidingPostCommentController {
@@ -38,4 +40,9 @@ public class RidingPostCommentController {
 		return CommandSuccessResult.from(commentId);
 	}
 
+	@GetMapping("/api/v1/ridingposts/{postid}/comments")
+	public RidingPostCommentListResult createRidingComment(@PathVariable("postid") long postId) {
+
+		return RidingPostCommentListResult.from(commentService.getCommentsByPostId(postId));
+	}
 }

--- a/src/main/java/com/prgrms/rg/web/ridingpost/requests/RidingPostCommentCreateRequest.java
+++ b/src/main/java/com/prgrms/rg/web/ridingpost/requests/RidingPostCommentCreateRequest.java
@@ -1,8 +1,7 @@
 package com.prgrms.rg.web.ridingpost.requests;
 
-import javax.validation.constraints.NotNull;
-
-import org.hibernate.validator.constraints.Length;
+import javax.annotation.Nullable;
+import javax.validation.constraints.NotEmpty;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -12,7 +11,9 @@ import lombok.NoArgsConstructor;
 @Data
 @AllArgsConstructor
 public class RidingPostCommentCreateRequest {
-	@NotNull
-	@Length(min = 1, max = 500)
+	@NotEmpty
 	private String content;
+
+	@Nullable
+	private Long parentCommentId;
 }

--- a/src/main/java/com/prgrms/rg/web/ridingpost/results/RidingPostCommentListResult.java
+++ b/src/main/java/com/prgrms/rg/web/ridingpost/results/RidingPostCommentListResult.java
@@ -1,0 +1,15 @@
+package com.prgrms.rg.web.ridingpost.results;
+
+import java.util.List;
+
+import com.prgrms.rg.domain.ridingpost.application.information.RidingPostCommentInfo;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor(staticName = "from")
+public class RidingPostCommentListResult {
+	private final List<RidingPostCommentInfo> comments;
+
+}

--- a/src/test/java/com/prgrms/rg/domain/ridingpost/application/impl/RidingPostCommentServiceImplTest.java
+++ b/src/test/java/com/prgrms/rg/domain/ridingpost/application/impl/RidingPostCommentServiceImplTest.java
@@ -41,7 +41,7 @@ class RidingPostCommentServiceImplTest {
 
 	@Test
 	@DisplayName("요청을 받아 사용자와 라이딩 게시물 정보와 연결된 댓글을 저장한다. - 부모 댓글")
-	void create_comment_successful() {
+	void create_parent_comment() {
 		// Given
 		var commentAuthor = createUser();
 		var leader = User.builder().nickname(new Nickname("leader")).manner(Manner.create()).build();
@@ -66,7 +66,7 @@ class RidingPostCommentServiceImplTest {
 
 	@Test
 	@DisplayName("요청을 받아 사용자와 라이딩 게시물 정보와 연결된 댓글을 저장한다. - 자식 댓글")
-	void create_child_comment_successful() {
+	void create_child_comment() {
 		// Given
 		var commentAuthor = createUser();
 		var leader = User.builder().nickname(new Nickname("leader")).manner(Manner.create()).build();
@@ -74,7 +74,7 @@ class RidingPostCommentServiceImplTest {
 		userRepository.save(leader);
 		var post = createRidingPost(leader.getId());
 		post = ridingPostRepository.save(post);
-		var parentComment = RidingPostComment.of(leader, post, "parent");
+		var parentComment = RidingPostComment.createRootComment(leader, post, "parent");
 		parentComment = ridingPostCommentRepository.save(parentComment);
 		var command = RidingPostCommentCreateCommand.of(commentAuthor.getId(), post.getId(), parentComment.getId(), "comment");
 
@@ -87,8 +87,10 @@ class RidingPostCommentServiceImplTest {
 		assertThat(savedComment.getContent()).isEqualTo("comment");
 		assertThat(savedComment.getAuthor()).isEqualTo(commentAuthor);
 		assertThat(savedComment.getRidingPost()).isNull();
-		assertThat(savedComment.getParentComment()).isEqualTo(parentComment);
-		assertThat(savedComment.getParentComment().getChildComments()).contains(savedComment);
+
+		RidingPostComment savedParentComment = savedComment.getParentComment();
+		assertThat(savedParentComment).isEqualTo(parentComment);
+		assertThat(savedParentComment.getChildComments()).contains(savedComment);
 
 	}
 
@@ -106,6 +108,43 @@ class RidingPostCommentServiceImplTest {
 		// Then
 		assertThatThrownBy(when)
 			.isInstanceOf(RelatedEntityNotFoundException.class);
+
+	}
+
+	@Test
+	@DisplayName("특정 RidingPost의 댓글들을 조회해서 생성 시간 기준 오름차순으로 반환한다.")
+	void query_comments_related_with_specific_riding_post() {
+
+		// Given
+		var commentAuthor = createUser();
+		var leader = User.builder().nickname(new Nickname("leader")).manner(Manner.create()).build();
+		userRepository.save(commentAuthor);
+		userRepository.save(leader);
+		var post = createRidingPost(leader.getId());
+		post = ridingPostRepository.save(post);
+
+		var rootComment = RidingPostComment.createRootComment(commentAuthor, post, "parent");
+		rootComment = ridingPostCommentRepository.save(rootComment);
+		var childCommentId = ridingPostCommentService.createComment(
+			RidingPostCommentCreateCommand.of(leader.getId(), post.getId(), rootComment.getId(), "child"));
+		var secondChildCommentId = ridingPostCommentService.createComment(
+			RidingPostCommentCreateCommand.of(leader.getId(), post.getId(), rootComment.getId(), "child2"));
+
+		// When
+		var commentsInfo = ridingPostCommentService.getCommentsByPostId(post.getId());
+
+		// Then
+		assertThat(commentsInfo).hasSize(1);
+		var rootCommentInfo = commentsInfo.get(0);
+		assertThat(rootCommentInfo.getAuthorName()).isEqualTo(commentAuthor.getNickname());
+		assertThat(rootCommentInfo.getChildComments()).hasSize(2);
+		assertThat(rootCommentInfo.getParentCommentId()).isZero();
+		var childCommentInfo = rootCommentInfo.getChildComments().get(0);
+		assertThat(childCommentInfo.getCommentId()).isEqualTo(childCommentId);
+		assertThat(childCommentInfo.getContents()).isEqualTo("child");
+		var secondChildCommentInfo = rootCommentInfo.getChildComments().get(1);
+		assertThat(secondChildCommentInfo.getCommentId()).isEqualTo(secondChildCommentId);
+		assertThat(secondChildCommentInfo.getContents()).isEqualTo("child2");
 
 	}
 

--- a/src/test/java/com/prgrms/rg/web/ridingpost/api/RidingPostCommentControllerTest.java
+++ b/src/test/java/com/prgrms/rg/web/ridingpost/api/RidingPostCommentControllerTest.java
@@ -46,7 +46,7 @@ class RidingPostCommentControllerTest {
 		var authorId = 1L;
 		var postId = 2L;
 		var token = tokenProvider.createToken("ROLE_USER", authorId);
-		var command = RidingPostCommentCreateCommand.of(authorId, postId, content);
+		var command = RidingPostCommentCreateCommand.of(authorId, postId, null, content);
 		given(ridingPostCommentService.createComment(command)).willReturn(1L);
 
 		// When
@@ -76,7 +76,7 @@ class RidingPostCommentControllerTest {
 		var authorId = 1L;
 		var postId = 2L;
 		var token = tokenProvider.createToken("ROLE_USER", authorId);
-		var command = RidingPostCommentCreateCommand.of(authorId, postId, content);
+		var command = RidingPostCommentCreateCommand.of(authorId, postId, null, content);
 		given(ridingPostCommentService.createComment(command)).willThrow(RelatedEntityNotFoundException.class);
 
 		// When


### PR DESCRIPTION
## 내용

* 대댓글 요구사항 반영 수정했습니다.
* Comment 엔티티를 두 가지 유형으로 나누었습니다. 나중에 리팩터링 할 때 타입을 두 개로 나눠볼 수도 있을 것 같네요. 
* 작성 성공 응답은 프론트와 맞춰서 id가 담긴 json으로 반환하도록 했습니다.
* 최대한 구현 빨리 하고 시간 남을 때 리팩터링 할게요
 ### rootComment
* RidingPost와 직접 연관 관계
* 연관 관계 맺은 부모 comment 없음

### childComment
* RidingPost와 연관 관계 X
* 부모 comment와 연관 관계
---

