### PR TITLE
[fix] 유저 정보 조회 api 프론트와 응답 형식 일치

### DIFF
--- a/src/main/java/com/prgrms/rg/domain/user/model/Manner.java
+++ b/src/main/java/com/prgrms/rg/domain/user/model/Manner.java
@@ -37,7 +37,7 @@ public class Manner {
 	}
 
 	MannerInfo information() {
-		return new MannerInfo(mannerLevel(), noShow, bannedUntil);
+		return new MannerInfo(point, noShow, bannedUntil);
 	}
 
 	MannerLevel mannerLevel() {

--- a/src/main/java/com/prgrms/rg/domain/user/model/RiderProfile.java
+++ b/src/main/java/com/prgrms/rg/domain/user/model/RiderProfile.java
@@ -41,23 +41,19 @@ public class RiderProfile {
 	 */
 	//TODO: User 생성자에서 UserBicycle 추가 불가능?
 
-	public RiderProfile(int ridingYears, RidingLevel level) {
-		this.ridingStartYear = Year.now().minusYears(ridingYears);
+	public RiderProfile(int ridingStartYear, RidingLevel level) {
+		this.ridingStartYear = Year.of(ridingStartYear);
 		this.level = level;
 	}
 
-	public RiderProfile(int ridingYears, RidingLevel level, Set<UserBicycle> bicycles) {
-		this.ridingStartYear = ridingYearsToStartingYear(ridingYears);
+	public RiderProfile(int ridingStartYear, RidingLevel level, Set<UserBicycle> bicycles) {
+		this.ridingStartYear = Year.of(ridingStartYear);
 		this.level = level;
 		this.bicycles = bicycles;
 	}
 
-	private Year ridingYearsToStartingYear(int ridingYears) {
-		return Year.now().minusYears(ridingYears);
-	}
-
-	public void update(int ridingYears, RidingLevel level, Set<UserBicycle> bicyclesToApply) {
-		this.ridingStartYear = ridingYearsToStartingYear(ridingYears);
+	public void update(int ridingStartYear, RidingLevel level, Set<UserBicycle> bicyclesToApply) {
+		this.ridingStartYear = Year.of(ridingStartYear);
 		this.level = level;
 		bicycles.retainAll(bicyclesToApply);
 		bicycles.addAll(bicyclesToApply);

--- a/src/main/java/com/prgrms/rg/domain/user/model/RiderProfile.java
+++ b/src/main/java/com/prgrms/rg/domain/user/model/RiderProfile.java
@@ -68,7 +68,7 @@ public class RiderProfile {
 	}
 
 	Year getRidingYears() {
-		return Year.now().minusYears(ridingStartYear.getValue());
+		return ridingStartYear;
 	}
 
 	RiderInfo information() {

--- a/src/main/java/com/prgrms/rg/domain/user/model/User.java
+++ b/src/main/java/com/prgrms/rg/domain/user/model/User.java
@@ -3,8 +3,8 @@ package com.prgrms.rg.domain.user.model;
 import static javax.persistence.GenerationType.*;
 import static lombok.AccessLevel.*;
 
-import java.util.regex.Pattern;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 import javax.persistence.Embedded;
 import javax.persistence.Entity;
@@ -23,7 +23,7 @@ import com.prgrms.rg.domain.common.model.metadata.Bicycle;
 import com.prgrms.rg.domain.common.model.metadata.RidingLevel;
 import com.prgrms.rg.domain.ridingpost.model.AddressCode;
 import com.prgrms.rg.domain.user.model.dto.UserRegisterDTO;
-
+import com.prgrms.rg.domain.user.model.information.ContactInfo;
 import com.prgrms.rg.domain.user.model.information.MannerInfo;
 import com.prgrms.rg.domain.user.model.information.RiderInfo;
 import com.prgrms.rg.domain.user.model.information.UserImageInfo;
@@ -55,8 +55,6 @@ public class User extends BaseTimeEntity implements ImageOwner {
 	@OneToOne(mappedBy = "user")
 	private ProfileImage profileImage;
 
-	//TODO: 연락처 추가
-
 	@Embedded
 	private Introduction introduction;
 
@@ -66,7 +64,10 @@ public class User extends BaseTimeEntity implements ImageOwner {
 
 	private boolean isRegistered;
 
+	//TODO: Partey 머지 이후 이메일과 전화번호 VO 분리 훈 리팩토링
 	private String phoneNumber;
+
+	private String email;
 
 	@JoinColumn(name = "address_code")
 	@ManyToOne(fetch = FetchType.LAZY)
@@ -76,8 +77,9 @@ public class User extends BaseTimeEntity implements ImageOwner {
 	private Manner manner;
 
 	public void updateByRegistration(UserRegisterDTO userRegisterDTO) {
-		 this.nickname = new Nickname(userRegisterDTO.getNickName());
-		 this.profile = new RiderProfile(userRegisterDTO.getRidingStartYear(), RidingLevel.of(userRegisterDTO.getLevel()));
+		this.nickname = new Nickname(userRegisterDTO.getNickName());
+		this.profile = new RiderProfile(userRegisterDTO.getRidingStartYear(),
+			RidingLevel.of(userRegisterDTO.getLevel()));
 
 		for (String bicycle : userRegisterDTO.getBicycles()) {
 			this.profile.addBicycle(this, new Bicycle(bicycle));
@@ -88,7 +90,7 @@ public class User extends BaseTimeEntity implements ImageOwner {
 	}
 
 	private void setPhoneNumber(String phoneNumber) {
-		if(!Pattern.matches("^01(?:0|1|[6-9])-(?:\\d{3}|\\d{4})-\\d{4}$", phoneNumber))
+		if (!Pattern.matches("^01(?:0|1|[6-9])-(?:\\d{3}|\\d{4})-\\d{4}$", phoneNumber))
 			throw new IllegalArgumentException("잘못된 번호입니다.");
 		this.phoneNumber = phoneNumber;
 	}
@@ -108,7 +110,7 @@ public class User extends BaseTimeEntity implements ImageOwner {
 	public boolean addBicycle(Bicycle bicycle) {
 		return profile.addBicycle(this, bicycle);
 	}
-	
+
 	public String getNickname() {
 		return nickname.get();
 	}
@@ -128,6 +130,10 @@ public class User extends BaseTimeEntity implements ImageOwner {
 
 	public MannerInfo getMannerInfo() {
 		return manner.information();
+	}
+
+	public ContactInfo getContactInfo() {
+		return new ContactInfo(phoneNumber, email);
 	}
 
 	@Override

--- a/src/main/java/com/prgrms/rg/domain/user/model/information/ContactInfo.java
+++ b/src/main/java/com/prgrms/rg/domain/user/model/information/ContactInfo.java
@@ -1,0 +1,15 @@
+package com.prgrms.rg.domain.user.model.information;
+
+import lombok.Getter;
+
+@Getter
+public class ContactInfo {
+
+	private String phoneNumber;
+	private String email;
+
+	public ContactInfo(String phoneNumber, String email) {
+		this.phoneNumber = phoneNumber;
+		this.email = email;
+	}
+}

--- a/src/main/java/com/prgrms/rg/domain/user/model/information/MannerInfo.java
+++ b/src/main/java/com/prgrms/rg/domain/user/model/information/MannerInfo.java
@@ -9,12 +9,12 @@ import lombok.Getter;
 @Getter
 public final class MannerInfo {
 
-	private MannerLevel level;
+	private int mannerPoint;
 	private short noShow;
 	private LocalDate bannedUntil;
 
-	public MannerInfo(MannerLevel level, short noShow, LocalDate bannedUntil) {
-		this.level = level;
+	public MannerInfo(int mannerPoint, short noShow, LocalDate bannedUntil) {
+		this.mannerPoint = mannerPoint;
 		this.noShow = noShow;
 		this.bannedUntil = bannedUntil;
 	}
@@ -22,7 +22,7 @@ public final class MannerInfo {
 	@Override
 	public String toString() {
 		return "MannerInfo{" +
-			"level=" + level +
+			"mannerPoint=" + mannerPoint +
 			", noShow=" + noShow +
 			", bannedUntil=" + bannedUntil +
 			'}';

--- a/src/main/java/com/prgrms/rg/domain/user/model/information/RiderInfo.java
+++ b/src/main/java/com/prgrms/rg/domain/user/model/information/RiderInfo.java
@@ -25,6 +25,14 @@ public final class RiderInfo {
 		return Collections.unmodifiableList(bicycles);
 	}
 
+	public String[] getBicyclesAsArray() {
+		String[] result = new String[bicycles.size()];
+		for (int i = 0; i < result.length; i++) {
+			result[i] = bicycles.get(i);
+		}
+		return result;
+	}
+
 	@Override
 	public String toString() {
 		return "RiderInfo{" +

--- a/src/main/java/com/prgrms/rg/domain/user/model/information/UserProfilePageInfo.java
+++ b/src/main/java/com/prgrms/rg/domain/user/model/information/UserProfilePageInfo.java
@@ -12,19 +12,21 @@ public class UserProfilePageInfo {
 	private UserImageInfo image;
 	private String introduction;
 	private MannerInfo manner;
-	//TODO: 라이딩 정보 로딩 후, 참여한 라이딩 횟수를 RiderInfoResult에 저장
+
+	private ContactInfo contact;
 
 	public UserProfilePageInfo(String nickname, RiderInfo profile,
-		UserImageInfo image, String introduction, MannerInfo manner) {
+		UserImageInfo image, String introduction, MannerInfo manner, ContactInfo contact) {
 		this.nickname = nickname;
 		this.profile = profile;
 		this.image = image;
 		this.introduction = introduction;
 		this.manner = manner;
+		this.contact = contact;
 	}
 
 	public static UserProfilePageInfo of(User user) {
 		return new UserProfilePageInfo(user.getNickname(), user.getRiderInformation(),
-			user.getImage(), user.getIntroduction(), user.getMannerInfo());
+			user.getImage(), user.getIntroduction(), user.getMannerInfo(), user.getContactInfo());
 	}
 }

--- a/src/main/java/com/prgrms/rg/web/user/results/MannerInfoResult.java
+++ b/src/main/java/com/prgrms/rg/web/user/results/MannerInfoResult.java
@@ -9,18 +9,18 @@ import lombok.Data;
 @Data
 public final class MannerInfoResult {
 
-	private String level;
+	private int mannerPoint;
 	private short noShow;
 	private LocalDate bannedUntil;
 
-	private MannerInfoResult(String level, short noShow, LocalDate bannedUntil) {
-		this.level = level;
+	private MannerInfoResult(int mannerPoint, short noShow, LocalDate bannedUntil) {
+		this.mannerPoint = mannerPoint;
 		this.noShow = noShow;
 		this.bannedUntil = bannedUntil;
 	}
 
 	public static MannerInfoResult of(MannerInfo mannerInfo) {
-		return new MannerInfoResult(mannerInfo.getLevel().toString(), mannerInfo.getNoShow(),
+		return new MannerInfoResult(mannerInfo.getMannerPoint(), mannerInfo.getNoShow(),
 			mannerInfo.getBannedUntil());
 	}
 }

--- a/src/main/java/com/prgrms/rg/web/user/results/UserProfileResult.java
+++ b/src/main/java/com/prgrms/rg/web/user/results/UserProfileResult.java
@@ -1,31 +1,91 @@
 package com.prgrms.rg.web.user.results;
 
-import com.prgrms.rg.domain.user.model.information.MannerInfo;
+import java.time.LocalDate;
+
 import com.prgrms.rg.domain.user.model.information.UserProfilePageInfo;
 
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
+@NoArgsConstructor
 public class UserProfileResult {
 
-	private String nickname;
-	private RiderInfoResult profile;
-	private ImageInfoResult image;
-	private String introduction;
-	private MannerInfo manner;
+	private PrivacyProfileResult privacyProfile;
+	private RiderProfileResult ridingProfile;
+	private MannerResult manner;
 
-	private UserProfileResult(String nickname, RiderInfoResult profile, ImageInfoResult image,
-		String introduction,
-		MannerInfo manner) {
-		this.nickname = nickname;
-		this.profile = profile;
-		this.image = image;
-		this.introduction = introduction;
+	private UserProfileResult(PrivacyProfileResult privacyProfile, RiderProfileResult ridingProfile,
+		MannerResult manner) {
+		this.privacyProfile = privacyProfile;
+		this.ridingProfile = ridingProfile;
 		this.manner = manner;
 	}
 
 	public static UserProfileResult of(UserProfilePageInfo info) {
-		return new UserProfileResult(info.getNickname(), RiderInfoResult.of(info.getProfile()),
-			ImageInfoResult.of(info.getImage()), info.getIntroduction(), info.getManner());
+		return new UserProfileResult(
+			new PrivacyProfileResult(info.getContact().getPhoneNumber(), info.getContact().getEmail()),
+			new RiderProfileResult(info.getNickname(), info.getImage().getFileUrl(), info.getIntroduction(),
+				info.getProfile().getRidingYears(),
+				info.getProfile().getLevel().getLevelName(), info.getProfile().getBicyclesAsArray()),
+			new MannerResult(info.getManner().getMannerPoint(), info.getManner().getNoShow(),
+				info.getManner().getBannedUntil()));
+	}
+
+	@Data
+	private static class PrivacyProfileResult {
+
+		public PrivacyProfileResult() {
+		}
+
+		public PrivacyProfileResult(String phoneNumber, String kakaoEmail) {
+			this.phoneNumber = phoneNumber;
+			this.kakaoEmail = kakaoEmail;
+		}
+
+		private String phoneNumber;
+		private String kakaoEmail;
+	}
+
+	@Data
+	private static class RiderProfileResult {
+
+		public RiderProfileResult() {
+		}
+
+		private String nickname;
+		private String profileImage;
+		private String introduction;
+		private int ridingStartYear;
+		private String level;
+		private String[] bicycles;
+
+		private RiderProfileResult(String nickname, String profileImage, String introduction, int ridingStartYear,
+			String level,
+			String[] bicycles) {
+			this.nickname = nickname;
+			this.profileImage = profileImage;
+			this.introduction = introduction;
+			this.ridingStartYear = ridingStartYear;
+			this.level = level;
+			this.bicycles = bicycles;
+		}
+	}
+
+	@Data
+	private static class MannerResult {
+
+		public MannerResult() {
+		}
+
+		private int mannerPoint;
+		private int noShow;
+		private LocalDate banned;
+
+		private MannerResult(int mannerPoint, int noShow, LocalDate banned) {
+			this.mannerPoint = mannerPoint;
+			this.noShow = noShow;
+			this.banned = banned;
+		}
 	}
 }

--- a/src/test/java/com/prgrms/rg/domain/user/application/impl/UserCommandServiceImplTest.java
+++ b/src/test/java/com/prgrms/rg/domain/user/application/impl/UserCommandServiceImplTest.java
@@ -4,6 +4,7 @@ import static com.prgrms.rg.domain.common.model.metadata.RidingLevel.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.time.Year;
 import java.util.List;
 
 import javax.persistence.EntityManager;
@@ -56,7 +57,7 @@ class UserCommandServiceImplTest {
 
 		User user = userRepository.save(User.builder()
 			.nickname(new Nickname("RGRider"))
-			.profile(new RiderProfile(5, MASTER))
+			.profile(new RiderProfile(2012, MASTER))
 			.introduction(new Introduction("한강 라이딩을 즐겨합니다."))
 			.manner(Manner.create())
 			.build());
@@ -64,8 +65,8 @@ class UserCommandServiceImplTest {
 		user.addBicycle(road);
 		user.addBicycle(seoulBike);
 
-		UserUpdateCommand command = new UserUpdateCommand(user.getId(), "changedName", 3
-			, BEGINNER.getLevelName(), new String[] {"따릉이", "MTB"}, "반갑습니다.");
+		UserUpdateCommand command = new UserUpdateCommand(user.getId(), "changedName", 2017, BEGINNER.getLevelName(),
+			new String[] {"따릉이", "MTB"}, "반갑습니다.");
 
 		em.flush();
 		em.clear();
@@ -80,7 +81,7 @@ class UserCommandServiceImplTest {
 
 		//Then
 		assertThat(afterEdited.getNickname()).isEqualTo("changedName");
-		assertThat(afterEdited.getRiderInformation().getRidingYears()).isEqualTo(3);
+		assertThat(afterEdited.getRiderInformation().getRidingYears()).isEqualTo(Year.of(2017));
 		assertThat(afterEdited.getRiderInformation().getLevel()).isEqualTo(BEGINNER);
 		List<String> changedBicycles = afterEdited.getRiderInformation().getBicycles();
 		assertThat(changedBicycles).containsAll(List.of("따릉이", "MTB")).doesNotContain("로드");

--- a/src/test/java/com/prgrms/rg/domain/user/application/impl/UserCommandServiceImplTest.java
+++ b/src/test/java/com/prgrms/rg/domain/user/application/impl/UserCommandServiceImplTest.java
@@ -81,7 +81,7 @@ class UserCommandServiceImplTest {
 
 		//Then
 		assertThat(afterEdited.getNickname()).isEqualTo("changedName");
-		assertThat(afterEdited.getRiderInformation().getRidingYears()).isEqualTo(Year.of(2017));
+		assertThat(afterEdited.getRiderInformation().getRidingYears()).isEqualTo(2017);
 		assertThat(afterEdited.getRiderInformation().getLevel()).isEqualTo(BEGINNER);
 		List<String> changedBicycles = afterEdited.getRiderInformation().getBicycles();
 		assertThat(changedBicycles).containsAll(List.of("따릉이", "MTB")).doesNotContain("로드");

--- a/src/test/java/com/prgrms/rg/web/user/api/UserCommandRestControllerV1Test.java
+++ b/src/test/java/com/prgrms/rg/web/user/api/UserCommandRestControllerV1Test.java
@@ -54,7 +54,6 @@ class UserCommandRestControllerV1Test {
 				.contentType("application/json")
 			).andExpect(status().isOk())
 			.andDo(print());
-
 	}
 
 	@Test

--- a/src/test/java/com/prgrms/rg/web/user/api/UserReadRestControllerV1Test.java
+++ b/src/test/java/com/prgrms/rg/web/user/api/UserReadRestControllerV1Test.java
@@ -1,0 +1,71 @@
+package com.prgrms.rg.web.user.api;
+
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.prgrms.rg.domain.auth.jwt.JwtTokenProvider;
+import com.prgrms.rg.domain.common.model.metadata.Bicycle;
+import com.prgrms.rg.domain.common.model.metadata.RidingLevel;
+import com.prgrms.rg.domain.user.application.UserReadService;
+import com.prgrms.rg.domain.user.model.Introduction;
+import com.prgrms.rg.domain.user.model.Manner;
+import com.prgrms.rg.domain.user.model.Nickname;
+import com.prgrms.rg.domain.user.model.RiderProfile;
+import com.prgrms.rg.domain.user.model.User;
+import com.prgrms.rg.domain.user.model.information.UserProfilePageInfo;
+import com.prgrms.rg.testutil.ControllerTest;
+
+@ControllerTest(controllers = UserReadRestControllerV1.class)
+class UserReadRestControllerV1Test {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@MockBean
+	UserReadService userReadService;
+
+	@Autowired
+	JwtTokenProvider tokenProvider;
+
+	@Autowired
+	ObjectMapper objectMapper;
+
+	@Test
+	@DisplayName("User 정보 수정 테스트")
+	void updateUserTest() throws Exception {
+		//Given
+		var token = tokenProvider.createToken("ROLE_USER", 1L);
+		User user = User.builder()
+			.id(1L)
+			.nickname(new Nickname("outwater"))
+			.introduction(
+				new Introduction("자기소개입니다. 저는 라이딩을 사랑하는 라죽남 입니다. 로드 MTB 따릉이 가리지 않고, 자전거가 있는 모든 곳을 환영합니다. 같이 타고 즐겨보아요."))
+			.manner(Manner.create())
+			.profile(new RiderProfile(2012, RidingLevel.INTERMEDIATE))
+			.phoneNumber("010-1234-5678")
+			.email("kakaoemail@naver.com")
+			.profileImage(null)
+			.build();
+		user.addBicycle(new Bicycle(1L, "로드"));
+		user.addBicycle(new Bicycle(2L, "따릉이"));
+		UserProfilePageInfo result = new UserProfilePageInfo(user.getNickname(), user.getRiderInformation(),
+			user.getImage(), user.getIntroduction(), user.getMannerInfo(), user.getContactInfo());
+
+		when(userReadService.getUserProfilePageInfo(1L)).thenReturn(result);
+
+		//When
+		mockMvc.perform(get(("/api/v1/users/1"))
+				.contentType("application/json")
+			).andExpect(status().isOk())
+			.andDo(print());
+	}
+}


### PR DESCRIPTION
- 프론트와 데이터 응답 형식을 일치시키기 위한 수정입니다.
- 관련 스펙: https://www.notion.so/backend-devcourse/api-v1-users-userid-27e3530b908c49f6bf6113a53152382e