### PR TITLE
[hotfix] 129 라이딩상세조회 수정

### DIFF
--- a/src/main/java/com/prgrms/rg/domain/ridingpost/model/RidingPostInfo.java
+++ b/src/main/java/com/prgrms/rg/domain/ridingpost/model/RidingPostInfo.java
@@ -1,6 +1,7 @@
 package com.prgrms.rg.domain.ridingpost.model;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -85,10 +86,11 @@ public class RidingPostInfo {
 		private static void mapMainSection(RidingMainSection mainSection, RidingInfo instance) {
 			if (mainSection == null)
 				return;
+			List<String> loadedCourse = new ArrayList<>(mainSection.getRoutes());
 			instance.setTitle(mainSection.getTitle());
 			instance.setRidingDate(mainSection.getRidingDate());
 			instance.setFee(mainSection.getFee());
-			instance.setRidingCourses(mainSection.getRoutes());
+			instance.setRidingCourses(loadedCourse);
 			instance.setDeparturePosition(mainSection.getDeparturePlace());
 			instance.setZone(ZoneInfo.from(mainSection.getAddressCode()));
 			instance.setEstimatedTime(mainSection.getEstimatedTime());

--- a/src/test/java/com/prgrms/rg/domain/ridingpost/application/impl/RidingPostReadServiceImplTest.java
+++ b/src/test/java/com/prgrms/rg/domain/ridingpost/application/impl/RidingPostReadServiceImplTest.java
@@ -87,6 +87,8 @@ class RidingPostReadServiceImplTest {
 
 		//when
 		RidingPostInfo ridingPostInfo = readService.loadRidingPostInfoById(savedPostId);
+		em.flush();
+		em.clear();
 
 		//then
 		RidingPostInfo.LeaderInfo leaderInfo = ridingPostInfo.getLeaderInfo();
@@ -100,7 +102,7 @@ class RidingPostReadServiceImplTest {
 		assertThat(ridingInfo.getRidingDate()).isEqualTo(ridingDate);
 		assertThat(ridingInfo.getFee()).isEqualTo(fee);
 		assertThat(ridingInfo.getZone().getCode()).isEqualTo(addressCode.getCode());
-		assertThat(ridingInfo.getRidingCourses()).isEqualTo(routes);
+		assertThat(ridingInfo.getRidingCourses()).contains("start", "end");
 		System.out.println(mapper.writeValueAsString(ridingPostInfo));
 	}
 

--- a/src/test/java/com/prgrms/rg/domain/ridingpost/application/impl/RidingPostReadServiceImplTest.java
+++ b/src/test/java/com/prgrms/rg/domain/ridingpost/application/impl/RidingPostReadServiceImplTest.java
@@ -87,8 +87,6 @@ class RidingPostReadServiceImplTest {
 
 		//when
 		RidingPostInfo ridingPostInfo = readService.loadRidingPostInfoById(savedPostId);
-		em.flush();
-		em.clear();
 
 		//then
 		RidingPostInfo.LeaderInfo leaderInfo = ridingPostInfo.getLeaderInfo();


### PR DESCRIPTION
#129 이슈 대응 PR
[slack issue](https://greppkdt-webdev.slack.com/archives/C03NYCGNWNA/p1660271601948539)

RidingPost -> RidingInfo DTO로 변환 과정에서 MainSection의 routes를 fetch하는 과정이 누락되어 발생된 에러였습니다.