### PR TITLE
[feat] 전역 validation 예외 처리 controlleradvice

### DIFF
--- a/src/main/java/com/prgrms/rg/web/common/message/ExceptionMessageSender.java
+++ b/src/main/java/com/prgrms/rg/web/common/message/ExceptionMessageSender.java
@@ -4,4 +4,6 @@ import javax.servlet.http.HttpServletRequest;
 
 public interface ExceptionMessageSender {
 	void send(Exception exception, HttpServletRequest request);
+
+	void send(String message, HttpServletRequest request);
 }

--- a/src/main/java/com/prgrms/rg/web/common/message/LocalSystemExceptionMessageSender.java
+++ b/src/main/java/com/prgrms/rg/web/common/message/LocalSystemExceptionMessageSender.java
@@ -18,4 +18,9 @@ public class LocalSystemExceptionMessageSender implements ExceptionMessageSender
 	public void send(Exception exception, HttpServletRequest request) {
 		log.warn(MessageFactory.createHttpMessage(request), exception);
 	}
+
+	@Override
+	public void send(String message, HttpServletRequest request) {
+		log.warn(message);
+	}
 }

--- a/src/main/java/com/prgrms/rg/web/common/message/MessageFactory.java
+++ b/src/main/java/com/prgrms/rg/web/common/message/MessageFactory.java
@@ -21,4 +21,7 @@ public class MessageFactory {
 		return stackStream.toString(StandardCharsets.UTF_8);
 	}
 
+	public static String createStringMessage(String message) {
+		return message;
+	}
 }

--- a/src/main/java/com/prgrms/rg/web/common/message/OuterSystemExceptionMessageSender.java
+++ b/src/main/java/com/prgrms/rg/web/common/message/OuterSystemExceptionMessageSender.java
@@ -25,4 +25,16 @@ public class OuterSystemExceptionMessageSender implements ExceptionMessageSender
 			log.error(messageException.getMessage(), messageException);
 		}
 	}
+
+	@Override
+	public void send(String message, HttpServletRequest request) {
+		log.warn(message);
+		try {
+			String prefixMessage = MessageFactory.createHttpMessage(request);
+			String bodyMessage = MessageFactory.createStringMessage(message);
+			CriticalMessageSender.send(prefixMessage + "\n" + bodyMessage);
+		} catch (Exception messageException) {
+			log.error(messageException.getMessage(), messageException);
+		}
+	}
 }

--- a/src/main/java/com/prgrms/rg/web/ridingpost/api/RidingPostController.java
+++ b/src/main/java/com/prgrms/rg/web/ridingpost/api/RidingPostController.java
@@ -5,7 +5,6 @@ import javax.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.annotation.Secured;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -29,26 +28,16 @@ public class RidingPostController {
 
 	@Secured("ROLE_USER")
 	@PostMapping(value = "/api/v1/ridingposts")
-	public ResponseEntity<Long> registerRidingPost(@AuthenticationPrincipal JwtAuthentication auth,
-		@RequestBody @Valid RidingPostSaveRequest ridingRequest, BindingResult result) {
-		if (result.hasErrors()) {
-			//todo 에러 메시지 포함
-			throw new IllegalArgumentException();
-		}
-
+	public ResponseEntity<Long> registerRidingPost(@Valid @RequestBody RidingPostSaveRequest ridingRequest,
+		@AuthenticationPrincipal JwtAuthentication auth) {
 		//return type : post id
 		return ResponseEntity.ok(ridingPostService.createRidingPost(auth.userId, ridingRequest.toCommand()));
 	}
 
 	@Secured("ROLE_USER")
 	@PutMapping(value = "/api/v1/ridingposts/{postid}")
-	public ResponseEntity<Long> modifyRidingPost(@AuthenticationPrincipal JwtAuthentication auth,
-		@PathVariable(name = "postid") Long postId, @RequestBody @Valid RidingPostSaveRequest ridingRequest
-		, BindingResult result) {
-		if (result.hasErrors()) {
-			//todo 에러 메시지 포함
-			throw new IllegalArgumentException();
-		}
+	public ResponseEntity<Long> modifyRidingPost(@Valid @RequestBody RidingPostSaveRequest ridingRequest,
+		@AuthenticationPrincipal JwtAuthentication auth, @PathVariable(name = "postid") Long postId) {
 		return ResponseEntity.ok(ridingPostService.updateRidingPost(auth.userId, postId, ridingRequest.toCommand()));
 	}
 

--- a/src/main/java/com/prgrms/rg/web/user/api/UserCommandRestControllerV1.java
+++ b/src/main/java/com/prgrms/rg/web/user/api/UserCommandRestControllerV1.java
@@ -1,5 +1,7 @@
 package com.prgrms.rg.web.user.api;
 
+import javax.validation.Valid;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.annotation.Secured;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -22,9 +24,9 @@ public class UserCommandRestControllerV1 implements UserRestController {
 
 	@Secured("ROLE_USER")
 	@PutMapping("/api/v1/users/{userId}")
-	public ResponseEntity<Long> editUser(@AuthenticationPrincipal JwtAuthentication auth,
-		@PathVariable(name = "userId") Long userId,
-		@RequestBody UserUpdateRequest request) {
+	public ResponseEntity<Long> editUser(@Valid @RequestBody UserUpdateRequest request,
+		@AuthenticationPrincipal JwtAuthentication auth,
+		@PathVariable(name = "userId") Long userId) {
 		return ResponseEntity.ok().body(userService.edit(request.toCommand(userId)));
 	}
 }

--- a/src/main/java/com/prgrms/rg/web/user/requests/UserUpdateRequest.java
+++ b/src/main/java/com/prgrms/rg/web/user/requests/UserUpdateRequest.java
@@ -1,5 +1,7 @@
 package com.prgrms.rg.web.user.requests;
 
+import javax.validation.constraints.NotBlank;
+
 import com.prgrms.rg.domain.user.application.command.UserUpdateCommand;
 
 import lombok.AllArgsConstructor;
@@ -11,8 +13,10 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class UserUpdateRequest {
 
+	@NotBlank
 	private String nickname;
 	private int ridingYears;
+	@NotBlank
 	private String ridingLevel;
 	private String[] bicycles;
 	private String introduction;

--- a/src/test/java/com/prgrms/rg/web/user/api/UserCommandRestControllerV1Test.java
+++ b/src/test/java/com/prgrms/rg/web/user/api/UserCommandRestControllerV1Test.java
@@ -5,6 +5,8 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+import java.util.Locale;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -57,8 +59,30 @@ class UserCommandRestControllerV1Test {
 	}
 
 	@Test
+	@DisplayName("User 정보 수정 - 잘못된 요청")
+	void updateUserTest_fail_with_Argument() throws Exception {
+		//Given
+		var token = tokenProvider.createToken("ROLE_USER", 1L);
+
+		var request = new UserUpdateRequest("RG라이더", 5, "",
+			new String[] {"MTB", "로드"}, "잘 부탁드립니다. 한강 라이딩을 즐겨 합니다.");
+
+		var body = objectMapper.writeValueAsString(request);
+
+		when(userCommandService.edit(isA(UserUpdateCommand.class))).thenReturn(1L);
+
+		//When
+		mockMvc.perform(put(("/api/v1/users/1"))
+				.header("Authorization", "token " + token)
+				.content(body)
+				.contentType("application/json")
+			).andExpect(status().isBadRequest())
+			.andDo(print());
+	}
+
+	@Test
 	@DisplayName("User 정보 수정 실패 - 잘못된 ID로 요청")
-	void request_without_token() throws Exception {
+	void request_with_invalid_id() throws Exception {
 
 		//Given
 		var token = tokenProvider.createToken("ROLE_USER", 1L);


### PR DESCRIPTION
- 프론트엔드 분들과 통합해나가는 과정에서 Validation 실패 상황을 빠르게 파악하기 위해 만들었습니다.
- 실제 운영 서버라면 Slack 메시지로 검증 실패 데이터를 보내지 않겠지만, 현재 저희 상황에서는 메시지를 보내는 편이 합당하리라고 생각해서 검증 실패 시에도 슬랙 채널로 메시지 전송됩니다.