### PR TITLE
[fix] 부모 댓글 삭제 -> 자식 댓글 삭제

### DIFF
--- a/src/main/java/com/prgrms/rg/domain/ridingpost/model/RidingPostComment.java
+++ b/src/main/java/com/prgrms/rg/domain/ridingpost/model/RidingPostComment.java
@@ -7,6 +7,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
+import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -41,7 +42,7 @@ public class RidingPostComment extends BaseTimeEntity {
 	@ManyToOne(fetch = LAZY)
 	private RidingPostComment parentComment;
 
-	@OneToMany(mappedBy = "parentComment")
+	@OneToMany(mappedBy = "parentComment", cascade = CascadeType.REMOVE)
 	private List<RidingPostComment> childComments;
 
 	@Column(length = 500, nullable = false)
@@ -72,13 +73,12 @@ public class RidingPostComment extends BaseTimeEntity {
 		this.contents = contents;
 	}
 
-	// TODO : 엔티티 분리
-	public boolean isRootComment() {
-		return Objects.nonNull(ridingPost);
+	public boolean isChildComment() {
+		return Objects.nonNull(parentComment);
 	}
 
 	private void assignToParent(RidingPostComment parentComment) {
-		checkArgument(!isRootComment(), "RidingPost가 존재할 경우 부모 댓글에 할당할 수 없습니다.");
+		checkArgument(!isChildComment(), "이미 부모 댓글이 존재합니다.");
 		checkNotNull(parentComment);
 		parentComment.getChildComments().add(this);
 		this.parentComment = parentComment;

--- a/src/main/java/com/prgrms/rg/domain/ridingpost/model/RidingPostCommentRepository.java
+++ b/src/main/java/com/prgrms/rg/domain/ridingpost/model/RidingPostCommentRepository.java
@@ -7,7 +7,7 @@ public interface RidingPostCommentRepository {
 
 	RidingPostComment save(RidingPostComment ridingPostComment);
 
-	List<RidingPostComment> findAllByRidingPost(RidingPost ridingPost);
+	List<RidingPostComment> findAllByRidingPostAndParentCommentIsNull(RidingPost ridingPost);
 
 	void delete(RidingPostComment ridingPostComment);
 }

--- a/src/main/java/com/prgrms/rg/infrastructure/repository/JpaRidingPostCommentRepository.java
+++ b/src/main/java/com/prgrms/rg/infrastructure/repository/JpaRidingPostCommentRepository.java
@@ -9,6 +9,6 @@ import com.prgrms.rg.domain.ridingpost.model.RidingPostComment;
 import com.prgrms.rg.domain.ridingpost.model.RidingPostCommentRepository;
 
 public interface JpaRidingPostCommentRepository extends JpaRepository<RidingPostComment, Long>, RidingPostCommentRepository {
-	List<RidingPostComment> findAllByRidingPost(RidingPost ridingPost);
+	List<RidingPostComment> findAllByRidingPostAndParentCommentIsNull(RidingPost ridingPost);
 
 }

--- a/src/main/java/com/prgrms/rg/web/ridingpost/api/RidingPostCommentController.java
+++ b/src/main/java/com/prgrms/rg/web/ridingpost/api/RidingPostCommentController.java
@@ -44,7 +44,7 @@ public class RidingPostCommentController {
 	}
 
 	@GetMapping("/api/v1/ridingposts/{postid}/comments")
-	public RidingPostCommentListResult createRidingComment(@PathVariable("postid") long postId) {
+	public RidingPostCommentListResult getRidingComment(@PathVariable("postid") long postId) {
 
 		return RidingPostCommentListResult.from(commentService.getCommentsByPostId(postId));
 	}


### PR DESCRIPTION
## 내용

* 부모 댓글 삭제 -> 자식 댓글 삭제 
(CascadeType.REMOVE) 적용

* 댓글 기준 변경
부모 댓글, 자식 댓글 모두 RidingPost와 ManyToOne 관계
최상위 부모 댓글 식별 방식 : 부모 댓글 연관 관계 null 유무